### PR TITLE
Create proxy directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ dist
 coverage
 bower_components
 purescript/output
+
+# proxy directories
+fantasy-land
+list
+methods
+ramda

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test-property": "mocha --timeout 0 --require ts-node/register --recursive test/property/*.ts",
     "codecov": "codecov -f coverage/coverage-final.json",
     "bench": "node bench",
-    "format": "prettier --write \"{src,test}/**/*.ts\"",
-    "prepublishOnly": "npm run build; cp -r dist/* .",
+    "format": "prettier --write \"{src,test,scripts}/**/*.{js,ts}\"",
+    "prepublishOnly": "npm run build; node ./scripts/make-proxies",
     "release": "np"
   },
   "author": "Simon Friis Vindum",

--- a/scripts/make-proxies.js
+++ b/scripts/make-proxies.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const path = require("path");
+const { promisify } = require("util");
+const pkg = require("../package.json");
+
+const readDir = promisify(fs.readdir);
+const mkDir = promisify(fs.mkdir);
+const writeFile = promisify(fs.writeFile);
+
+const noop = () => {};
+
+const removeExt = (ext, str) => path.basename(str, `.${ext}`);
+
+const fileProxy = file => `{
+  "name": "${pkg.name}/${removeExt("js", file)}",
+  "private": true,
+  "main": "../dist/${file}",
+  "module": "../dist/es/${file}"
+}
+`;
+
+async function processDir(dir) {
+  const files = (await readDir(dir)).filter(
+    file => /\.js$/.test(file) && file !== "index.js"
+  );
+  return await Promise.all(
+    files.map(async file => {
+      const proxyDir = removeExt("js", file);
+      await mkDir(proxyDir).catch(noop);
+      await writeFile(`${proxyDir}/package.json`, fileProxy(file));
+      return proxyDir;
+    })
+  );
+}
+
+processDir("dist").then(proxies =>
+  console.log(`Proxy directories (${proxies.join(", ")}) generated!`)
+);


### PR DESCRIPTION
This will allow tools to pick appropriate files when importing "sub"-packages, like `list/ramda`.
