### PR TITLE
Removed ramda as peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
   },
   "author": "Simon Friis Vindum",
   "license": "MIT",
-  "peerDependencies": {
-    "ramda": "*"
-  },
   "module": "es/index.js",
   "sideEffects": false,
   "devDependencies": {


### PR DESCRIPTION
Having `ramda` as peerDep makes npm and co to warn us against missing peer dep

This behaviour somewhat means that peerDeps are required and `ramda` is certainly not in case of `list`. We could make it an optionalDependency, but truly I don't know what's the benefit of that.