### PR TITLE
Adjusted sideEffects, specify fantasy-land & methods as effectful

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "author": "Simon Friis Vindum",
   "license": "MIT",
-  "sideEffects": false,
+  "sideEffects": ["**/fantasy-land.js", "**/methods.js"],
   "devDependencies": {
     "@types/chai": "4.1.2",
     "@types/mocha": "2.2.48",


### PR DESCRIPTION
fixes #8

webpack@4 got released, i've checked quickly and for this input
```js
import * as L from "list"
import "list/fantasy-land";

console.log(L.list(0, 1, 2, 3))
```
this config
```js
const webpack = require('webpack');

module.exports = {
  devtool: false,
  optimization: {
    minimize: false,
  }
}
```
and this script
```
webpack --mode production
```

effectful fantasy-land entry was not included. I don't think more complex patterns (array, objects) are possible in sideEffects field just yet and if they are they can be added in followup PRs.