### PR TITLE
Use property-based tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,12 @@
       "integrity": "sha512-CNPC7KqhmOYhTtD4zFJDkmZ+i8UcCoVOXKq1MDpjduxkoP6aCWVdnZQTaeN8qtz89bMxkCHcMu4mUTqwuKlyYw==",
       "dev": true
     },
+    "@types/random-js": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@types/random-js/-/random-js-1.0.30.tgz",
+      "integrity": "sha512-WjnCxSADI8zNFkwwQYzBbYDOMOsX//gzxS7rLvms4E8dEcHPrKzoi4FZXebYLKlTpaWSSqHT3Fp9TkDAiNW5rw==",
+      "dev": true
+    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -1102,6 +1108,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stringify-pretty-compact": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.1.0.tgz",
+      "integrity": "sha512-KlHWclgmjtRCbMdUxCJY8AZAIlJLeH0lu3VO9ocaY5Lndfc24YvCOUe3izrIcA8A53uCNIolAXsxouDOWj5kww==",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3798,6 +3810,17 @@
       "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
       "dev": true
     },
+    "proptest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/proptest/-/proptest-0.0.4.tgz",
+      "integrity": "sha1-1AlSh+Rr+HU0up2CaODCOqYO0/M=",
+      "dev": true,
+      "requires": {
+        "@types/random-js": "1.0.30",
+        "json-stringify-pretty-compact": "1.1.0",
+        "random-js": "1.0.8"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -3826,6 +3849,12 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
       "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
+      "dev": true
+    },
+    "random-js": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/random-js/-/random-js-1.0.8.tgz",
+      "integrity": "sha1-lo/WiabyXWwKrHZig94vaIycGQo=",
       "dev": true
     },
     "rc": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "np": "^2.19.0",
     "nyc": "11.4.1",
     "prettier": "1.11.1",
+    "proptest": "0.0.4",
     "ramda": "0.25.0",
     "source-map-support": "^0.5.3",
     "ts-node": "5.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,16 +216,6 @@ function cloneNode({ sizes, array }: Node): Node {
   );
 }
 
-function suffixToNode<A>(suffix: A[]): Node {
-  // FIXME: should take size and copy
-  return new Node(undefined, suffix);
-}
-
-function prefixToNode<A>(prefix: A[]): Node {
-  // FIXME: should take size and copy
-  return new Node(undefined, reverseArray(prefix));
-}
-
 function setSizes(node: Node, height: number): Node {
   let sum = 0;
   const sizeTable = [];

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 
-import * as QC from "ts-quickcheck";
+import * as P from "proptest";
 
 import { installCheck } from "./check";
 import * as Loriginal from "../src";
@@ -64,13 +64,13 @@ import {
 } from "../src";
 import "../src/fantasy-land";
 
-const check = QC.createProperty(it);
+const check = P.createProperty(it);
 
 // Generates a list with length between 0 and size
-const genList = QC.nat.map(n => range(0, n));
+const genList = P.nat.map(n => range(0, n));
 
 // Generates a list with length in the full 32 integer range
-const genBigList = QC.natural.map(n => range(0, n));
+const genBigList = P.natural.map(n => range(0, n));
 
 function numberArray(start: number, end: number): number[] {
   let array = [];
@@ -389,7 +389,7 @@ describe("List", () => {
     });
     check(
       "is associative",
-      QC.three(QC.range(1_000_000).map(n => range(0, n / 3))),
+      P.three(P.range(1_000_000).map(n => range(0, n / 3))),
       ([xs, ys, zs]) => {
         const lhs = concat(xs, concat(ys, zs));
         const rhs = concat(concat(xs, ys), zs);
@@ -1250,12 +1250,10 @@ describe("List", () => {
   describe("splitAt and concat", () => {
     check(
       "are inverses",
-      QC.range(2)
+      P.range(2)
         .big()
         .array()
-        .chain(xs =>
-          QC.record({ xs: QC.Gen.of(xs), i: QC.range(xs.length + 1) })
-        ),
+        .chain(xs => P.record({ xs: P.Gen.of(xs), i: P.range(xs.length + 1) })),
       ({ xs, i }) => {
         const li = list(...xs);
         const [left, right] = splitAt(i, li);


### PR DESCRIPTION
This WIP PR adds property-based testing based on @danr's [ts-quickcheck](https://github.com/danr/ts-quickcheck).

The goal is to make the test suite more concise due to not having to specify concrete examples, to catch more bugs and achieve greater certainty in correctness.

I'll merge this PR once ts-quickcheck can properly be added as a dependency. That should be possible after https://github.com/danr/ts-quickcheck/pull/9.