### PR TITLE
Add sort, sortBy, and sortWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,25 +238,23 @@ and behavior as Ramdas functions.
 
 The goal is to implement the entirety of Ramda's array functions for
 List. The list below keeps track of how many of Ramda functions that
-are missing and of how many that are already implemented. Currently 45
+are missing and of how many that are already implemented. Currently 46
 out of 75 functions have been implemented.
 
-Implemented: `adjust`, `all`, `any`, `append`, `chain`, `concat`,
-`contains`, `drop`, `dropLast`, `dropWhile`, `filter`, `find`,
-`findIndex`, `head`, `flatten`, `indexOf`, `init`, `insert`,
-`insertAll`, `last`, `length`, `join`, `map`, `none`, `nth`, `pair`,
-`partition`, `pluck`, `prepend`, `range`, `reduce`, `reduceRight`,
-`reject`, `remove`, `reverse`, `repeat`, `slice`, `splitAt`, `take`,
-`takeWhile`, `tail`, `takeLast`, `times`, `update`,
+Implemented: `adjust`, `all`, `any`, `append`, `chain`, `concat`, `contains`,
+`drop`, `dropLast`, `dropWhile`, `filter`, `find`, `findIndex`, `head`,
+`flatten`, `indexOf`, `init`, `insert`, `insertAll`, `last`, `length`, `join`,
+`map`, `none`, `nth`, `pair`, `partition`, `pluck`, `prepend`, `range`,
+`reduce`, `reduceRight`, `reject`, `remove`, `reverse`, `repeat`, `slice`,
+`sort`, `splitAt`, `take`, `takeWhile`, `tail`, `takeLast`, `times`, `update`,
 `zip`, `zipWith`.
 
-Not implemented: `aperture`, `dropLastWhile`, `dropRepeats`,
-`dropRepeatsWith`, `endsWith`, `findLast`, `findLastIndex`,
-`groupWith`, `indexBy`, `intersperse`, `lastIndexOf`, `mapAccum`,
-`mapAccumRight`, `reduceWhile`, `scan`, `sequence`, `sort`,
+Not implemented: `aperture`, `dropLastWhile`, `dropRepeats`, `dropRepeatsWith`,
+`endsWith`, `findLast`, `findLastIndex`, `groupWith`, `indexBy`, `intersperse`,
+`lastIndexOf`, `mapAccum`, `mapAccumRight`, `reduceWhile`, `scan`, `sequence`,
 `splitEvery`, `splitWhen`, `startsWith`, `takeLastWhile`, `transpose`,
-`traverse`, `unfold`, `uniq`, `uniqBy`, `uniqWith`,
-`unnest` `without`, `xprod`.
+`traverse`, `unfold`, `uniq`, `uniqBy`, `uniqWith`, `unnest` `without`,
+`xprod`.
 
 ## Fantasy Land & Static Land
 
@@ -268,7 +266,7 @@ specifications: Setoid, semigroup, monoid, foldable, functor, apply,
 applicative, chain, monad.
 
 The following specifications have not been implemented yet:
-Traversable.
+Traversable, Ord.
 
 Since methods hinder tree-shaking the Fantasy Land methods are not
 included by default. In order to get them you must import it likes
@@ -791,6 +789,72 @@ Iterate over two lists in parallel and collect the pairs.
 const names = list("a", "b", "c", "d", "e");
 const years = list(0, 1, 2, 3, 4, 5, 6);
 //=> list(["a", 0], ["b", 1], ["c", 2], ["d", 3], ["e", 4]);
+```
+
+### `sort`
+
+Sorts the given list. The list should contain values that can be compared using
+the `<` operator or values that implement the Fantasy Land
+[Ord](https://github.com/fantasyland/fantasy-land#ord) specification.
+
+Performs a stable sort.
+
+**Complexity**: `O(n * log(n))`
+
+**Example**
+
+```js
+sort(list(5, 3, 1, 8, 2)); //=> list(1, 2, 3, 5, 8)
+sort(list("e", "a", "c", "b", "d"); //=> list("a", "b", "c", "d", "e")
+```
+
+### `sortBy`
+
+Sort the given list by passing each value through the function and comparing
+the resulting value. The function should either return values comparable using
+`<` or values that implement the Fantasy Land
+[Ord](https://github.com/fantasyland/fantasy-land#ord) specification.
+
+Performs a stable sort.
+
+**Complexity**: `O(n * log(n))`
+
+**Example**
+
+```js
+sortBy(o => o.n, list({ n: 4, m: "foo" }, { n: 3, m: "bar" }, { n: 1, m: "baz" }));
+//=> list({ n: 1, m: "baz" }, { n: 3, m: "bar" }, { n: 4, m: "foo" })
+
+sortBy(s => s.length, list("foo", "bar", "ba", "aa", "list", "z"));
+//=> list("z", "ba", "aa", "foo", "bar", "list")
+```
+
+### `sortWith`
+
+Sort the given list by comparing values using the given function. The function
+receieves two values and should return `-1` if the first value is stricty
+larger than the second, `0` is they are equal and `1` if the first values is
+strictly smaller than the second.
+
+Note that the comparison function is equivalent to the one required by
+[`Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
+
+Performs a stable sort.
+
+**Complexity**: `O(n * log(n))`
+
+**Example**
+
+```js
+sortWith((a, b) => {
+  if (a === b) {
+    return 0;
+  } else if (a < b) {
+    return -1;
+  } else {
+    return 1;
+  }
+}, list(5, 3, 1, 8, 2)); //=> list(1, 2, 3, 5, 8)
 ```
 
 ### Folds

--- a/src/curried.ts
+++ b/src/curried.ts
@@ -19,7 +19,8 @@ export {
   fromArray,
   toArray,
   reverse,
-  fromIterable
+  fromIterable,
+  sort
 } from "./index";
 
 export interface Curried2<A, B, R> {
@@ -159,6 +160,16 @@ export const splitAt: typeof L.splitAt &
   ((index: number) => <A>(l: List<A>) => [List<A>, List<A>]) = curry2(
   L.splitAt
 );
+
+export const sortBy: typeof L.sortBy &
+  (<A, B extends L.Comparable>(
+    f: (a: A) => B
+  ) => (l: List<A>) => List<A>) = curry2(L.sortBy);
+
+export const sortWith: typeof L.sortWith &
+  (<A>(
+    comparator: (a: A, b: A) => L.Ordering
+  ) => (l: List<A>) => List<A>) = curry2(L.sortWith);
 
 export const zip: typeof L.zip &
   (<A>(as: List<A>) => <B>(bs: List<B>) => List<[A, B]>) = curry2(L.zip);

--- a/src/ramda.ts
+++ b/src/ramda.ts
@@ -68,3 +68,6 @@ export const insert = curry(L.insert);
 export const insertAll = curry(L.insertAll);
 export const zip = curry(L.zip);
 export const zipWith = curry(L.zipWith);
+export const sort = curry(L.sort);
+export const sortWith = curry(L.sortWith);
+export const sortBy = curry(L.sortBy);

--- a/test/bench/report.ts
+++ b/test/bench/report.ts
@@ -89,6 +89,7 @@ async function runBenchmarks(argv: any): Promise<void> {
   (<any>require)("./update.perf");
   (<any>require)("./insert.perf");
   (<any>require)("./iterator.perf");
+  (<any>require)("./sort.perf");
   (<any>require)("./foldl-iterator.perf");
 
   const startTime = Date.now();

--- a/test/bench/sort.perf.ts
+++ b/test/bench/sort.perf.ts
@@ -1,0 +1,129 @@
+const shuffle = require("knuth-shuffle").knuthShuffle;
+
+import * as _ from "lodash";
+import * as R from "ramda";
+
+import { benchmark } from "./report";
+
+import { List } from "immutable";
+import * as Finger from "@paldepind/finger-tree";
+
+import * as Benchmark from "benchmark";
+
+import * as L from "../../dist/index";
+import "../../dist/methods";
+import * as Lo from "./list-old/dist/index";
+import "./list-old/dist/methods";
+
+let arr: number[];
+let list: L.List<number>;
+let l: any;
+let imm: any;
+
+function copyArray<A>(arr: A[]): A[] {
+  const newArray = [];
+  for (let i = 0; i < arr.length; ++i) {
+    newArray.push(arr[i]);
+  }
+  return newArray;
+}
+
+function comparePrimitive(a: number, b: number): -1 | 0 | 1 {
+  if (a === b) {
+    return 0;
+  } else if (a < b) {
+    return -1;
+  } else {
+    return 1;
+  }
+}
+
+function sortUnstable<A extends number | string>(l: L.List<A>): L.List<A> {
+  return L.fromArray(L.toArray(l).sort(comparePrimitive as any));
+}
+
+benchmark(
+  {
+    name: "sort, numbers",
+    description: "Sort a list of numbers",
+    input: [50, 100, 1000, 5000, 10000, 50000],
+    before: n => {
+      arr = [];
+      for (let i = 0; i < n; ++i) {
+        arr.push(i);
+      }
+      shuffle(arr);
+    }
+  },
+  {
+    Ramda: {
+      run: () => {
+        return R.sort(comparePrimitive, arr).length;
+      }
+    },
+    List: {
+      before: _ => {
+        l = L.fromArray(arr);
+      },
+      run: () => {
+        return L.sort(l).length;
+      }
+    },
+    Array: {
+      run: () => {
+        return copyArray(arr).sort().length;
+      }
+    },
+    "Array, with comparator": {
+      run: () => {
+        return copyArray(arr).sort(comparePrimitive).length;
+      }
+    },
+    "Immutable.js": {
+      before: _ => {
+        imm = List(arr);
+      },
+      run: () => {
+        return imm.sort().length;
+      }
+    }
+  }
+);
+
+benchmark(
+  {
+    name: "sort, stable vs unstable",
+    description: "Compares the cost of doing a stable search",
+    input: [50, 100, 1000, 5000, 10000, 50000],
+    before: n => {
+      arr = [];
+      for (let i = 0; i < n; ++i) {
+        arr.push(i);
+      }
+      shuffle(arr);
+    }
+  },
+  {
+    List: {
+      before: _ => {
+        l = L.fromArray(arr);
+      },
+      run: () => {
+        return L.sort(l).length; // Uses unstable sort since numbers
+      }
+    },
+    "List, stable": {
+      before: _ => {
+        l = L.fromArray(arr);
+      },
+      run: () => {
+        return L.sortWith(comparePrimitive, l).length; // Uses stable sort
+      }
+    },
+    "Array#sort": {
+      run: () => {
+        return copyArray(arr).sort(comparePrimitive).length;
+      }
+    }
+  }
+);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1406,4 +1406,110 @@ describe("List", () => {
       assertListEqual(L.zip(as, bs), list(["a", 0], ["b", 1], ["c", 2]));
     });
   });
+  describe("sorting", () => {
+    class Pair {
+      constructor(readonly fst: number, readonly snd: number) {}
+      "fantasy-land/lte"(b: Pair): boolean {
+        if (this.fst === b.fst) {
+          return this.snd <= b.snd;
+        } else {
+          return this.fst <= b.fst;
+        }
+      }
+    }
+    function compareNumber(a: number, b: number): -1 | 0 | 1 {
+      if (a === b) {
+        return 0;
+      } else if (a < b) {
+        return -1;
+      } else {
+        return 1;
+      }
+    }
+    const unsorted = list(
+      { n: 2, m: 1 },
+      { n: 1, m: 1 },
+      { n: 1, m: 2 },
+      { n: 1, m: 3 },
+      { n: 0, m: 1 },
+      { n: 3, m: 1 }
+    );
+    const unsortedPairs = list(
+      new Pair(2, 1),
+      new Pair(1, 1),
+      new Pair(1, 2),
+      new Pair(1, 2),
+      new Pair(1, 3),
+      new Pair(0, 1),
+      new Pair(3, 1)
+    );
+    it("sort returns same list on empty list ", () => {
+      const l = empty();
+      assert.strictEqual(l, L.sort(l));
+    });
+    it("sort sorts primitives ", () => {
+      const l = L.list(5, 2, 9, 1, 7, 3, 9);
+      assert.deepEqual(L.toArray(L.sort(l)), L.toArray(l).sort());
+    });
+    it("sort sorts Fantasy Land Ords", () => {
+      const sorted = L.sort(unsortedPairs);
+      const sortedPairs = [
+        new Pair(0, 1),
+        new Pair(1, 1),
+        new Pair(1, 2),
+        new Pair(1, 2),
+        new Pair(1, 3),
+        new Pair(2, 1),
+        new Pair(3, 1)
+      ];
+      assert.deepEqual(L.toArray(sorted), sortedPairs);
+    });
+    it("sortBy returns same list on empty list ", () => {
+      const l = empty();
+      assert.strictEqual(
+        l,
+        L.sortBy(_ => {
+          throw new Error("Should not be called");
+        }, l)
+      );
+    });
+    it("sortBy is stable", () => {
+      const sorted = L.sortBy(e => e.n, unsorted);
+      assert.deepEqual(L.toArray(sorted), [
+        { n: 0, m: 1 },
+        { n: 1, m: 1 },
+        { n: 1, m: 2 },
+        { n: 1, m: 3 },
+        { n: 2, m: 1 },
+        { n: 3, m: 1 }
+      ]);
+    });
+    it("sortBy sort Fantasy Land Ords", () => {
+      const unsorted = L.map(
+        pair => ({ pair, sum: pair.fst + pair.snd }),
+        unsortedPairs
+      );
+      const sorted = L.sortBy(o => o.pair, unsorted);
+      assert.deepEqual(L.toArray(sorted), [
+        { pair: new Pair(0, 1), sum: 1 },
+        { pair: new Pair(1, 1), sum: 2 },
+        { pair: new Pair(1, 2), sum: 3 },
+        { pair: new Pair(1, 2), sum: 3 },
+        { pair: new Pair(1, 3), sum: 4 },
+        { pair: new Pair(2, 1), sum: 3 },
+        { pair: new Pair(3, 1), sum: 4 }
+      ]);
+    });
+    it("sortWith is stable", () => {
+      const sorted = L.sortWith((a, b) => compareNumber(a.n, b.n), unsorted);
+      assert.deepEqual(L.toArray(sorted), [
+        { n: 0, m: 1 },
+        { n: 1, m: 1 },
+        { n: 1, m: 2 },
+        { n: 1, m: 3 },
+        { n: 2, m: 1 },
+        { n: 3, m: 1 }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds `sort`, `sortBy` and `sortWith`. These functions deviate from Ramda, because I personally don't think Ramda's sorting functions are optimal.

* All the sorting functions are _stable_.
* `sort` takes a single argument: a list to sort. The list is allowed to contain either numbers, strings, or Fantasy Land `Ord`s.
* `sortWith` takes a comparator function. This is similar to Ramda's `sort` function it is _not_ the same as Ramda's `sortWith`.
* `sortBy` is the same as Ramda's `sortBy` except the function may return a Fantasy Land `Ord` as well.

I'll have to add documentation before it gets merged.