### PR TITLE
Filter handles user-defined type guards

### DIFF
--- a/src/curried.ts
+++ b/src/curried.ts
@@ -87,6 +87,7 @@ export const range: typeof L.range &
   ((start: number) => (end: number) => List<number>) = curry2(L.range);
 
 export const filter: typeof L.filter &
+  (<A, B extends A>(predicate: (a: A) => a is B) => (l: List<A>) => List<B>) &
   (<A>(predicate: (a: A) => boolean) => (l: List<A>) => List<A>) = curry2(
   L.filter
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -827,6 +827,11 @@ export function forEach<A>(callback: (a: A) => void, l: List<A>): void {
   foldl((_, element) => callback(element), undefined as void, l);
 }
 
+export function filter<A, B extends A>(
+  predicate: (a: A) => a is B,
+  l: List<A>
+): List<B>;
+export function filter<A>(predicate: (a: A) => boolean, l: List<A>): List<A>;
 export function filter<A>(predicate: (a: A) => boolean, l: List<A>): List<A> {
   return foldl((acc, a) => (predicate(a) ? append(a, acc) : acc), empty(), l);
 }
@@ -1776,7 +1781,9 @@ function sliceTreeList<A>(
         const newRoot =
           childRight !== undefined
             ? childRight
-            : childLeft !== undefined ? childLeft : tree.array[pathLeft];
+            : childLeft !== undefined
+              ? childLeft
+              : tree.array[pathLeft];
         l.root = new Node(newRoot.sizes, newRoot.array); // Is this size handling good enough?
       }
     } else {

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -23,6 +23,7 @@ declare module "./index" {
     reduceRight<B>(f: (value: A, acc: B) => B, initial: B): B;
     forEach(callback: (a: A) => void): void;
     filter(predicate: (a: A) => boolean): List<A>;
+    filter<B extends A>(predicate: (a: A) => a is B): List<B>;
     reject(predicate: (a: A) => boolean): List<A>;
     partition(predicate: (a: A) => boolean): List<List<A>>;
     join(separator: string): string;

--- a/test/curried.ts
+++ b/test/curried.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 
 import * as L from "../src/index";
 import * as Lc from "../src/curried";
+import { assertListEqual } from ".";
 
 const exceptions = ["setEquals"];
 
@@ -37,6 +38,16 @@ describe("curried", () => {
     assert.isTrue(Lc.equals(l, Lc.list(0, 1, 2)));
     // Should not give type error since `l` is list of `number`
     assert.equal(Lc.foldl((a: number, b: number) => a + b, 0, l), 3);
+  });
+  it("curried filter works with user-defined type guards", () => {
+    function pred(a: any): a is string {
+      return typeof a === "string";
+    }
+    const filterPred = Lc.filter(pred);
+    const l = L.list<number | string>(0, "one", 2, "three", 4, "five");
+    const l2 = filterPred(l);
+    const l3 = L.map(s => s[0], l2);
+    assertListEqual(l3, L.list("o", "t", "f"));
   });
   it("can call foldl in all combinations", () => {
     const f = (sum: number, s: string) => sum + s.length;

--- a/test/index.ts
+++ b/test/index.ts
@@ -132,7 +132,7 @@ function assertIndexEqual<A>(i: number, l1: List<A>, l2: List<A>): void {
   assert.deepEqual(nth(i, l1), nth(i, l2), `expected equality at index ${i}`);
 }
 
-function assertListEqual<A>(l1: List<A>, l2: List<A>): void {
+export function assertListEqual<A>(l1: List<A>, l2: List<A>): void {
   assert.equal(l1.length, l2.length, "same length");
   const length = l1.length;
   if (length > 500) {
@@ -723,6 +723,15 @@ describe("List", () => {
       for (let i = 0; i < length(l2); ++i) {
         assert.isTrue(isEven(nth(i, l2)!), `${i} is ${nth(i, l2)}`);
       }
+    });
+    it("works with user-defined type guards", () => {
+      function pred(a: any): a is string {
+        return typeof a === "string";
+      }
+      const l = L.list<number | string>(0, "one", 2, "three", 4, "five");
+      const l2 = L.filter(pred, l);
+      const l3 = L.map(s => s[0], l2);
+      assertListEqual(l3, L.list("o", "t", "f"));
     });
     it("rejects element", () => {
       const l1 = list(0, 1, 2, 3, 4, 5, 6);


### PR DESCRIPTION
This PR improves the types of `filter` such that it better handles user-defined type guards. This idea was taken from @nordfjord's work here: https://github.com/paldepind/flyd/pull/173

Example.

```ts
function isString(a: any): a is string {
  return typeof a === "string";
}
// A list containing elements of several different types
const l = L.list<number | string>(0, "one", 2, "three", 4, "five");
// After filtering with the type guard the returned list will now have a more precise type
const l2 = L.filter(isString, l);
// TypeScript now knows that l2 contains only strings :)
const l3 = L.map(s => s.padStart(6), l2);
```