### PR TITLE
correct nomenclature?

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ for constructing lists:
 ```js
 // An array literal
 const myArray = [0, 1, 2, 3];
-// A list "literal"
+// A list object
 const myList = L.list(0, 1, 2, 3);
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ mySet.has("third"); //=> true
 This works because the `Set` constructor accepts any iterable as
 argument.
 
-Lists also work with [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). For instannce, you can call a function like this.
+Lists also work with [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax). For instance, you can call a function like this.
 
 ```js
 console.log(...list("hello", "there", "i'm", "logging", "elements"));


### PR DESCRIPTION
Maybe I'm misunderstanding something but my comprehension of the docs was tripped up by the word "literal" in quotation marks. Feel free to close if you think it's too pedantic.

The array literal is a literal because it *IS LITERALLY* the array object (which is then assigned to a variable.) The `list` object is not a literal anything, because there is no syntax in native javascript to construct one except by calling the function.