### PR TITLE
fix building a list from an iterable when that one uses a falsy done

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -419,7 +419,7 @@ export function from<A>(sequence: any): List<A> {
     const iterator = sequence[Symbol.iterator]();
     let cur;
     // tslint:disable-next-line:no-conditional-assignment
-    while ((cur = iterator.next()).done === false) {
+    while (!(cur = iterator.next()).done) {
       push(cur.value, l);
     }
   }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1608,6 +1608,19 @@ describe("List", () => {
       assert.strictEqual(l.length, 20);
       assertIndicesFromTo(l, 0, 20);
     });
+    it("converts an iterable into a list same as Array.from even with falsy done", () => {
+      const iterable = () =>
+        <any>{
+          [Symbol.iterator]() {
+            let idx = 0;
+            return {
+              next: () => (idx++ === 0 ? { value: 1 } : { done: true })
+            };
+          }
+        };
+      const l = from(iterable());
+      assert.deepEqual(Array.from(iterable()), L.toArray(l));
+    });
     it("converts an array into a list", () => {
       assertListEqual(L.list(0, 1, 2, 3, 4), L.from([0, 1, 2, 3, 4]));
     });


### PR DESCRIPTION
hello, i'm considering making https://github.com/emmanueltouzery/prelude.ts use `list` as a dependency for the implementation of the Vector. `list` has better performance for especially append & prepend in a loop, which is nice to have. I've spent some time trying to reimplement all the cool bits from list in prelude.ts's Vector, and had some success, but i'm not done yet, getting tired of it, and seeing less and less point in the exercise :-)

so, porting prelude.ts I stumbled on a little issue, which is that in your latest code when building a list from an iterable, you assume that `done` will be actually `false` when the iterator is not done.

Actually I think that's what the mozilla docs say... but that's not what `Array.from` implements ;-) indeed the https://github.com/mattbierner/hamt_plus library does produce an iterator which does _not_ have a 'done' field (so it's undefined, so it's falsy) except for the last iteration:
https://github.com/mattbierner/hamt_plus/blob/master/lib/hamt.js#L821

On such an iterator, `Array.from` works fine, and the current prelude.ts as well, but `list` produces an empty list. This PR fixes that.

PS: I'll answer to our conversation on the prelude.ts repo ASAP, sorry for the delay :-(
PPS: I see that travis failed but it's due to a travis timeout. The tests do pass.