### PR TITLE
first and last correctly uses affix sizes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -870,11 +870,12 @@ export function length(l: List<any>): number {
  * first(list()); //=> undefined
  */
 export function first<A>(l: List<A>): A | undefined {
-  if (getPrefixSize(l) !== 0) {
-    return arrayLast(l.prefix);
-  } else if (getSuffixSize(l) !== 0) {
-    return arrayFirst(l.suffix);
-  }
+  const prefixSize = getPrefixSize(l);
+  return prefixSize !== 0
+    ? l.prefix[prefixSize - 1]
+    : l.length !== 0
+      ? l.suffix[0]
+      : undefined;
 }
 
 /**
@@ -888,11 +889,12 @@ export function first<A>(l: List<A>): A | undefined {
  * last(list()); //=> undefined
  */
 export function last<A>(l: List<A>): A | undefined {
-  if (getSuffixSize(l) !== 0) {
-    return arrayLast(l.suffix);
-  } else if (getPrefixSize(l) !== 0) {
-    return arrayFirst(l.prefix);
-  }
+  const suffixSize = getSuffixSize(l);
+  return suffixSize !== 0
+    ? l.suffix[suffixSize - 1]
+    : l.length !== 0
+      ? l.prefix[0]
+      : undefined;
 }
 
 // map

--- a/test/index.ts
+++ b/test/index.ts
@@ -404,6 +404,11 @@ describe("List", () => {
       assert.strictEqual(first(list()), undefined);
       assert.strictEqual(last(list()), undefined);
     });
+    it("returns the first element based on prefix size", () => {
+      const l = L.prepend(0, L.empty());
+      L.prepend(1, l);
+      assert.strictEqual(L.first(l), 0);
+    });
     it("gets the last element of prepended list", () => {
       const l = prepend(0, prepend(1, prepend(2, empty())));
       assert.strictEqual(last(l), 2);
@@ -419,6 +424,11 @@ describe("List", () => {
     it("can get the first element when suffix overflows", () => {
       assert.strictEqual(first(appendList(0, 33)), 0);
     });
+    it("returns the last element based on suffix size", () => {
+      const l = L.append(0, L.empty());
+      L.append(1, l);
+      assert.strictEqual(L.last(l), 0);
+  });
   });
   describe("concat", () => {
     check("has left identity", genList, l => {


### PR DESCRIPTION
`first` and `last` didn't use the stored size of the prefix and suffix when accessing the prefix and suffix. This broke operations that rely on the affix size: `prepend` and `append` which mutate the affix and `slice` which changes the affix sizes to slice.

The change in this PR fixes the bug in `first` and `last`. An alternative fix would be to simply define `first` and `last` based on `nth` like this:

```ts
function first(l) {
  return nth(0, l);
}
```

That is simpler but would likely be slightly slower than the specialized `first` and `last` implementation. What do you think about those two options @emmanueltouzery?

Fixes #64.