### PR TITLE
bug #67: fix corruption when using slice and offset is present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2500,7 +2500,7 @@ export function slice<A>(from: number, to: number, l: List<A>): List<A> {
       newList.root = sliceLeft(
         newList.root!,
         getDepth(l),
-        from - prefixSize + l.offset,
+        from - prefixSize,
         l.offset,
         true
       );

--- a/test/index.ts
+++ b/test/index.ts
@@ -1886,5 +1886,20 @@ describe("List", () => {
 
       assertListEqual(f, L.from(g));
     });
+    it("handles slice well, second case", () => {
+      let f = L.list<number>();
+      let g: number[] = [];
+
+      f = L.concat(f, L.from(arrayOfLength(2891)));
+      g = [...g, ...arrayOfLength(2891)];
+
+      f = L.reverse(f);
+      g = g.reverse();
+
+      f = L.drop(267, f);
+      g = g.slice(267);
+
+      assertListEqual(f, L.from(g));
+    });
   });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -1860,4 +1860,31 @@ describe("List", () => {
       assert.isFalse(L.isEmpty(L.list(0, 1, 2, 3)));
     });
   });
+  describe("check slice issue", () => {
+    function arrayOfLength(l: number) {
+      const r = [];
+      for (let i = 0; i < l; i++) {
+        r.push(i);
+      }
+      return r;
+    }
+    it("handles slice well when offset is present", () => {
+      let f = L.list<number>();
+      let g: number[] = [];
+
+      f = L.concat(f, L.from(arrayOfLength(5440)));
+      g = [...g, ...arrayOfLength(5440)];
+
+      f = L.concat(f, L.from(arrayOfLength(6338)));
+      g = [...g, ...arrayOfLength(6338)];
+
+      f = L.drop(4194, f);
+      g = g.slice(4194);
+
+      f = L.drop(6229, f);
+      g = g.slice(6229);
+
+      assertListEqual(f, L.from(g));
+    });
+  });
 });


### PR DESCRIPTION
I think this is the correct fix for the latest issue I highlighted in bug #67. It definitely must be carefully reviewed though, because I don't fully understand everything.