### PR TITLE
bug #72: slice the prefix & suffix on slice even if not strictly needed to allow GC

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2491,7 +2491,9 @@ export function slice<A>(from: number, to: number, l: List<A>): List<A> {
   if (0 < from) {
     // we need to slice something off of the left
     if (from < prefixSize) {
-      // do a cheap slice by setting prefix length
+      // shorten the prefix even though it's not strictly needed,
+      // so that referenced items can be GC'd
+      newList.prefix = l.prefix.slice(0, prefixSize - from);
       bits = setPrefix(prefixSize - from, bits);
     } else {
       // if we're here `to` can't lie in the tree, so we can set the
@@ -2517,6 +2519,9 @@ export function slice<A>(from: number, to: number, l: List<A>): List<A> {
     // we need to slice something off of the right
     if (length - to < suffixSize) {
       bits = setSuffix(suffixSize - (length - to), bits);
+      // slice the suffix even though it's not strictly needed,
+      // to allow the removed items to be GC'd
+      newList.suffix = l.suffix.slice(0, suffixSize - (length - to));
     } else {
       newList.root = sliceRight(
         newList.root!,


### PR DESCRIPTION
This should fix the case I highlighted in bug #72, however I wonder whether there's not a more important case of this when `offset` is increased.

Could that be such a case there? =>

```typescript
    // If we've sliced something away and it's not a the root, update offset
    if (tree.sizes === undefined && top === false) {
      newOffset |= (32 - (tree.array.length - path)) << (depth * branchBits);
    }
```

(is it possible in this case "dead" items are referenced in the "removed" left part of the trie?)