### PR TITLE
Add documentaton for the isEmpty function in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ ap(list((n: number) => n + 2, n => 2 * n, n => n * n), list(1, 2, 3)); //=> list
 Maps a function over a list and concatenates all the resulting lists
 together.
 
-Also known as `flatMap`.
+**Aliases**: `flatMap`
 
 **Example**
 
@@ -1031,6 +1031,20 @@ isList([0, 1, 2]); //=> false
 isList("string"); //=> false
 isList({ foo: 0, bar: 1 }); //=> false
 isList(list(0, 1, 2)); //=> true
+```
+
+### `isEmpty`
+
+Returns `true` if the list is empty.
+
+**Complexity**: `O(1)`
+
+**Example**
+
+```js
+isEmpty(empty()); //=> true
+isEmpty(list()); //=> true
+isEmpty(list(0, 1, 2)); //=> false
 ```
 
 ### `equals`


### PR DESCRIPTION
The documentation inside `README.md` is missing for the `isEmpty` function. This seems particularly benign, but since I'd like to use the `list` package for a functional programming course, this becomes a bit more important.

This pull request only modifies the `README.md` file. It adds a documentation to the `isEmpty` function, in a simlar manner to the remainder of the file. It also makes a slight modification inside the documentation for the `flatMap` function, reusing the same style as the other functions in the documentation for the name aliases. This second modification should have been in its own commit, but I considered it is a one-liner inside a documentation file. 